### PR TITLE
Fix/8/wrong object returned

### DIFF
--- a/pytos/securetrack/helpers.py
+++ b/pytos/securetrack/helpers.py
@@ -1610,13 +1610,14 @@ class Secure_Track_Helper(Secure_API_Helper):
             response_string = self.get_uri(
                     "/securetrack/api/devices/{}/network_objects/{}".format(device_id, network_object_id),
                     expected_status_codes=200).response.content
-            network_object = Network_Objects_List.from_xml_string(response_string)[0]
+            network_object = [network_object for network_object in Network_Objects_List.from_xml_string(response_string)
+                              if network_object.id == network_object_id][0]
         except RequestException:
-            message = "Failed to get the list of rules for device ID {}.".format(device_id)
+            message = "Failed to get network objects for device ID {}.".format(device_id)
             logger.critical(message)
             raise IOError(message)
         except (REST_Not_Found_Error, IndexError):
-            message = "Device with ID {} does not exist.".format(device_id)
+            message = "Object with ID {} does not exist on Device with ID {}.".format(network_object_id, device_id)
             logger.critical(message)
             raise ValueError(message)
         if network_object.device_id is None:

--- a/tests/securetrack_test/test_secure_track_helper_unittest.py
+++ b/tests/securetrack_test/test_secure_track_helper_unittest.py
@@ -503,10 +503,10 @@ class TestNetworkObjects(unittest.TestCase):
     def test_04_get_network_object_by_device_and_object_id(self):
         self.mock_get_uri.return_value.content = fake_request_response("network_objects")
         with patch('pytos.common.rest_requests.requests.Request') as mock_get_uri:
-            network_object = self.helper.get_network_object_by_device_and_object_id(158, 3418214)
+            network_object = self.helper.get_network_object_by_device_and_object_id(158, 3433950)
             mock_get_uri.assert_called_with(
                 'GET',
-                'https://localhost/securetrack/api/devices/158/network_objects/3418214',
+                'https://localhost/securetrack/api/devices/158/network_objects/3433950',
                 auth=('username', 'password'),
                 headers={},
                 params=None


### PR DESCRIPTION
Fixes incorrect network objects being returned by `st_helper.get_network_object_by_device_and_object_id` for #8. Also updates tests to use real object id.